### PR TITLE
Update `Typed-Ast` to version `1.5.2`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 525a2d4088e70a9f75b08b3f87a51acc9cde640e19cc523c7e41aa355564ae27
 
 build:
-  number: 1
+  number: 0
   script: {{ PYTHON }} -m pip install . -vv
   skip: true  # [py2k]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv
-  skip: true  # [py2k]
+  skip: true  # [py36]
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,11 +11,10 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv
-  skip: true  # [py36]
+  skip: true  # [py<36]
 
 requirements:
   build:
-    - python                                 # [build_platform != target_platform]
     - {{ compiler('c') }}
   host:
     - python

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.4.3" %}
+{% set version = "1.5.2" %}
 
 package:
   name: typed-ast
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/t/typed_ast/typed_ast-{{ version }}.tar.gz
-  sha256: fb1bbeac803adea29cedd70781399c99138358c26d05fcbd23c13016b7f5ec65
+  sha256: 525a2d4088e70a9f75b08b3f87a51acc9cde640e19cc523c7e41aa355564ae27
 
 build:
   number: 1


### PR DESCRIPTION

  `typed-ast` version `1.5.2`
1. - [x] check the upstream
    https://github.com/python/typed_ast/tree/1.5.2

2. - [x] check the pinnings

https://github.com/python/typed_ast/blob/1.5.2/setup.py

minimal python version supported is `python` version `3.6`
https://github.com/python/typed_ast/blob/1.5.2/setup.py#L126

3. - [x] check the changelogs

A changelog was not provided, however the commit log was used to see the latest changes

https://github.com/python/typed_ast/commits/1.5.2


4. - [x] additional research
    https://github.com/conda-forge/typed-ast-feedstock/issues

There were currently no open issues mentioned in `conda-forge`

5. - [x] verify dev_url

    https://github.com/python/typed_ast

6. - [x] verify doc_url

    https://github.com/python/typed_ast/blob/master/README.md

7. - [x] license is spdx compliant

    There are many licenses in the recipe

8. - [x] license family
9. - [x] verify the build number
10. - [x] verify setuptools
     - setuptools is in the recipe
11. - [x] verify wheel
     - wheel is in the recipe
12. - [x] pip in the test section
     - pip is in the test section
13. - [x] veriy the test section

Results:
-


Based on the research findings and the results we can conclude
that it is safe to update `typed-ast` to version `1.5.2`
