### PR TITLE
update to 1.5.5

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,16 +1,18 @@
-{% set version = "1.5.2" %}
+{% set name = typed-ast}
+{% set alt_name = name|replace('-','_')}
+{% set version = "1.5.5" %}
 
 package:
-  name: typed-ast
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/t/typed_ast/typed_ast-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/t/{{ alt_name }}/{{ alt_name }}-{{ version }}.tar.gz
   sha256: 525a2d4088e70a9f75b08b3f87a51acc9cde640e19cc523c7e41aa355564ae27
 
 build:
   number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   skip: true  # [py<36]
 
 requirements:
@@ -35,7 +37,7 @@ test:
 about:
   home: https://github.com/python/typed_ast
   license: Apache-2.0 AND PSF-2.0 AND MIT
-  license_family: Apache
+  license_family: Other
   license_file: LICENSE
   summary: a fork of Python 2 and 3 ast modules with type comment support
   description: |
@@ -45,7 +47,7 @@ about:
     of Python under which they are run. The typed_ast parsers produce the
     standard Python AST (plus type comments), and are both fast and correct, as
     they are based on the CPython 2.7 and 3.6 parsers.
-  doc_url: https://github.com/python/typed_ast/blob/master/README.md
+  doc_url: https://github.com/python/typed_ast
   dev_url: https://github.com/python/typed_ast
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,7 +8,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/t/{{ name_var }}/{{ name_var }}-{{ version }}.tar.gz
-  sha256: 525a2d4088e70a9f75b08b3f87a51acc9cde640e19cc523c7e41aa355564ae27
+  sha256: 94282f7a354f36ef5dbce0ef3467ebf6a258e370ab33d5b40c249fa996e590dd
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
-{% set name = typed-ast}
-{% set alt_name = name|replace('-','_')}
+{% set name = "typed-ast" %}
+{% set name_var = name|replace("-", "_") %}
 {% set version = "1.5.5" %}
 
 package:
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/t/{{ alt_name }}/{{ alt_name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/t/{{ name_var }}/{{ name_var }}-{{ version }}.tar.gz
   sha256: 525a2d4088e70a9f75b08b3f87a51acc9cde640e19cc523c7e41aa355564ae27
 
 build:


### PR DESCRIPTION

typed-ast 5

**Destination channel:** defaults

### Links

- [PKG-3887]
- [Upstream repository]()
- [Upstream changelog/diff]()
- Relevant dependency PRs:
- ...

### Explanation of changes:

- ...
    

[PKG-3887]: https://anaconda.atlassian.net/browse/PKG-3887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ