### PR TITLE
typed-ast 1.5.5 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,4 @@
 {% set name = "typed-ast" %}
-{% set name_var = name|replace("-", "_") %}
 {% set version = "1.5.5" %}
 
 package:
@@ -7,11 +6,11 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/t/{{ name_var }}/{{ name_var }}-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name.replace("-", "_") }}-{{ version }}.tar.gz
   sha256: 94282f7a354f36ef5dbce0ef3467ebf6a258e370ab33d5b40c249fa996e590dd
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   skip: true  # [py<36]
 


### PR DESCRIPTION
typed-ast 1.5.5 

**Destination channel:** Defaults

### Links

- [PKG-8240]
- dev_url:        https://github.com/python/typed_ast/tree/1.5.5
- conda_forge:    https://github.com/conda-forge/typed-ast-feedstock
- pypi:           https://pypi.org/project/typed-ast/1.5.5
- pypi inspector: https://inspector.pypi.io/project/typed-ast/1.5.5

### Explanation of changes:

- feedstock added to aggregate
- rebuild for fixing compatibility with CRM and the recipe-bumper


[PKG-8240]: https://anaconda.atlassian.net/browse/PKG-8240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ